### PR TITLE
feat: application layer for makeBooking

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,6 @@
 NODE_ENV=development
 LOG_LEVEL=debug
+
+QUEUE_EMIT_TICKETS=
+
+TOPIC_BOOKINGS=

--- a/.swcrc
+++ b/.swcrc
@@ -1,11 +1,15 @@
 {
   "jsc": {
     "target" : "es2022",
+    "baseUrl": ".",
     "parser": {
       "syntax": "typescript",
       "tsx": false,
       "decorators": true,
-      "dynamicImport": false
+      "dynamicImport": true
     }
+  },
+  "module": {
+    "type": "commonjs"
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -5,20 +5,15 @@ include makefiles/docker.mk
 include makefiles/format.mk
 include makefiles/help.mk
 
-.PHONY: create.env-file ## Create a .env file based on sample
-create.env-file:
+create.env-file: ## Creates a local .env file based on sample
 	cp .env.sample .env
 
-.PHONY: setup ## Setup environment
-setup: create.env-file install
+setup: create.env-file install ## Setup environment
 
-.PHONY: test ## Run tests on docker
 test: format.check create.env-file docker.tests ## Run tests locally
 
-.PHONY: install ## Install packages
-install:
+install: ## Install packages
 	pnpm install
 
-.PHONY: dev
-dev: setup docker.run ## Install an run the server locally
+dev: setup docker.run ## Install and run the server locally
 	pnpm dev

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,4 @@ install: ## Install packages
 	pnpm install
 
 dev: setup docker.run ## Install and run the server locally
-	pnpm dev
+	pnpm dev:webapi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
       context: .
       dockerfile: ./docker/Dockerfile
     env_file: .env
+    environment:
+      APP_NAME: webapi
     ports:
-      - 4600:4600
+      - 4500:4500
 
   tests:
     container_name: tests

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 FROM base
 COPY --from=prod-deps /app/node_modules /app/node_modules
-COPY --from=build /app/dist /app/dist
+COPY --from=build /app/dist /app
 ENV NODE_ENV=production
 EXPOSE ${PORT}
 

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -6,4 +6,4 @@ COPY . ./app
 WORKDIR /app
 
 RUN pnpm install --frozen-lockfile
-CMD pnpm test:unit
+CMD pnpm test

--- a/makefiles/docker.mk
+++ b/makefiles/docker.mk
@@ -1,8 +1,5 @@
-docker.start: ## Get containers up
-	docker compose up --detach
-
 docker.start.recreate: ## Recreate and get containers up
-	docker compose up --detach --force-recreate
+	docker compose --profile dev up --detach --force-recreate
 
 docker.rebuild: ## Rebuild and get containers up for development
 	docker compose --profile dev up --build
@@ -13,11 +10,11 @@ docker.run: ## Get containers up for development
 docker.tests: ##format.check   Run all testes
 	docker compose --profile tests up --build --timeout 10 --abort-on-container-exit tests
 
-docker.stop: ## Get containers down
+docker.stop: ## Get all containers down
 	docker compose down
 
 docker.remove: ## Stop and remove containers
 	docker compose stop && docker compose rm -vf
 
-docker.spy: ## Show containers logs
-	docker compose logs -f
+docker.spy: ## Show API container logs
+	docker compose logs -f api

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   },
   "scripts": {
     "build": "swc ./src -d ./dist",
-    "start": "node ./src/index.js --optimize_for_size --max-semi-space-size=2048 --max-old-space-size=2048",
-    "start:dist": "node ./dist/src/index.js --optimize_for_size --max-semi-space-size=2048 --max-old-space-size=2048",
-    "dev:webapi": "pnpm ts-node-dev --clear --inspect --transpile-only --ignore node_modules -r dotenv/config src/index.ts webapi",
-    "test:unit": "jest --silent --maxWorkers=2"
+    "start": "node ./src/index.js",
+    "start:dist": "node ./dist/src/index.js",
+    "dev:webapi": "nodemon --exec swc-node ./src/index.ts webapi",
+    "test": "jest --silent --maxWorkers=2"
   },
   "dependencies": {
     "class-validator": "^0.14.1",
@@ -55,10 +55,11 @@
     "eslint-plugin-prettier": "^4.2.1",
     "fishery": "^2.2.2",
     "jest": "^29.7.0",
+    "nodemon": "^3.1.4",
     "prettier": "^2.8.8",
     "supertest": "^7.0.0",
+    "swc-node": "^1.0.0",
     "ts-jest": "^29.1.5",
-    "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "build": "swc ./src -d ./dist",
     "start": "node ./src/index.js --optimize_for_size --max-semi-space-size=2048 --max-old-space-size=2048",
+    "start:dist": "node ./dist/src/index.js --optimize_for_size --max-semi-space-size=2048 --max-old-space-size=2048",
     "dev:webapi": "pnpm ts-node-dev --clear --inspect --transpile-only --ignore node_modules -r dotenv/config src/index.ts webapi",
     "test:unit": "jest --silent --maxWorkers=2"
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "build": "swc ./src -d ./dist",
-    "dev": "pnpm ts-node-dev --clear --inspect --transpile-only --ignore node_modules -r dotenv/config src/index.ts service:",
     "start": "node ./src/index.js --optimize_for_size --max-semi-space-size=2048 --max-old-space-size=2048",
+    "dev:webapi": "pnpm ts-node-dev --clear --inspect --transpile-only --ignore node_modules -r dotenv/config src/index.ts webapi",
     "test:unit": "jest --silent --maxWorkers=2"
   },
   "dependencies": {
@@ -20,6 +20,7 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
+    "reflect-metadata": "^0.2.2",
     "semantic-release": "^24.0.0",
     "tsyringe": "^4.8.0",
     "uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.1.0",
-    "reflect-metadata": "^0.2.2",
     "semantic-release": "^24.0.0",
     "tsyringe": "^4.8.0",
     "uuid": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "fishery": "^2.2.2",
     "jest": "^29.7.0",
     "prettier": "^2.8.8",
+    "supertest": "^7.0.0",
     "ts-jest": "^29.1.5",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,18 +117,21 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5))
+      nodemon:
+        specifier: ^3.1.4
+        version: 3.1.4
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
       supertest:
         specifier: ^7.0.0
         version: 7.0.0
+      swc-node:
+        specifier: ^1.0.0
+        version: 1.0.0(@swc/core@1.6.1)(@swc/types@0.1.8)(typescript@5.4.5)
       ts-jest:
         specifier: ^29.1.5
         version: 29.1.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5)))(typescript@5.4.5)
-      ts-node-dev:
-        specifier: ^2.0.0
-        version: 2.0.0(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5)
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
@@ -607,6 +610,22 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@swc-node/core@1.13.1':
+    resolution: {integrity: sha512-emB5l2nZsXjUEAuusqjYvWnQMLWZp6K039Mv8aq5SX1rsNM/N7DNhw1i4/DX7AyzNZ0tT+ASWyTvqEURldp5HA==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      '@swc/core': '>= 1.4.13'
+      '@swc/types': '>= 0.1'
+
+  '@swc-node/register@1.9.2':
+    resolution: {integrity: sha512-BBjg0QNuEEmJSoU/++JOXhrjWdu3PTyYeJWsvchsI0Aqtj8ICkz/DqlwtXbmZVZ5vuDPpTfFlwDBZe81zgShMA==}
+    peerDependencies:
+      '@swc/core': '>= 1.4.13'
+      typescript: '>= 4.3'
+
+  '@swc-node/sourcemap-support@0.5.0':
+    resolution: {integrity: sha512-fbhjL5G0YvFoWwNhWleuBUfotiX+USiA9oJqu9STFw+Hb0Cgnddn+HVS/K5fI45mn92e8V+cHD2jgFjk4w2T9Q==}
+
   '@swc/cli@0.3.12':
     resolution: {integrity: sha512-h7bvxT+4+UDrLWJLFHt6V+vNAcUNii2G4aGSSotKz1ECEk4MyEh5CWxmeSscwuz5K3i+4DWTgm4+4EyMCQKn+g==}
     engines: {node: '>= 16.14.0'}
@@ -801,12 +820,6 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
-
-  '@types/strip-bom@3.0.0':
-    resolution: {integrity: sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==}
-
-  '@types/strip-json-comments@0.0.30':
-    resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
@@ -1203,6 +1216,9 @@ packages:
   color@3.2.1:
     resolution: {integrity: sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   colorspace@1.1.4:
     resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
 
@@ -1424,9 +1440,6 @@ packages:
 
   duplexer2@0.1.4:
     resolution: {integrity: sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==}
-
-  dynamic-dedupe@0.3.0:
-    resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2023,6 +2036,9 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  ignore-by-default@1.0.1:
+    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
+
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
@@ -2604,11 +2620,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  mkdirp@1.0.4:
-    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -2654,6 +2665,11 @@ packages:
 
   node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+
+  nodemon@3.1.4:
+    resolution: {integrity: sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   normalize-package-data@6.0.1:
     resolution: {integrity: sha512-6rvCfeRW+OEZagAB4lMLSNuTNYZWLVtKccK79VSTf//yTY5VOCgcpH80O+bZK8Neps7pUnd5G+QlMg1yV/2iZQ==}
@@ -3025,6 +3041,9 @@ packages:
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
 
+  pstree.remy@1.1.8:
+    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
+
   pump@3.0.0:
     resolution: {integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==}
 
@@ -3137,11 +3156,6 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rimraf@2.7.1:
-    resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
@@ -3249,6 +3263,10 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -3423,6 +3441,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swc-node@1.0.0:
+    resolution: {integrity: sha512-4+kibROq06E7Yj3kEcCRN1Ki2C/5i+5P1B7An9iS9PO1BQY5VzWFuLhV7y7xNxkZjc8FEaLCh97NGzs/XBfOMQ==}
+    hasBin: true
+
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
@@ -3478,13 +3500,13 @@ packages:
     resolution: {integrity: sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==}
     engines: {node: '>=14.16'}
 
+  touch@3.1.1:
+    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
+    hasBin: true
+
   traverse@0.6.9:
     resolution: {integrity: sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==}
     engines: {node: '>= 0.4'}
-
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
 
   trim-repeated@2.0.0:
     resolution: {integrity: sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==}
@@ -3524,17 +3546,6 @@ packages:
       esbuild:
         optional: true
 
-  ts-node-dev@2.0.0:
-    resolution: {integrity: sha512-ywMrhCfH6M75yftYvrvNarLEY+SUXtUvU8/0Z6llrHQVBx12GiFk5sStF8UdfE/yfzk9IAq7O5EEbTQsxlBI8w==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    peerDependencies:
-      node-notifier: '*'
-      typescript: '*'
-    peerDependenciesMeta:
-      node-notifier:
-        optional: true
-
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -3552,11 +3563,11 @@ packages:
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
-  tsconfig@7.0.0:
-    resolution: {integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==}
-
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.6.3:
+    resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
   tsyringe@4.8.0:
     resolution: {integrity: sha512-YB1FG+axdxADa3ncEtRnQCFq/M0lALGLxSZeVNbTU8NqhOVc51nnv2CISTcvc1kyv6EGPtXVr0v6lWeDxiijOA==}
@@ -3626,6 +3637,9 @@ packages:
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  undefsafe@2.0.5:
+    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -3824,7 +3838,7 @@ snapshots:
       '@babel/traverse': 7.24.7
       '@babel/types': 7.24.7
       convert-source-map: 2.0.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3998,7 +4012,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.24.7
       '@babel/types': 7.24.7
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -4019,6 +4033,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@dabh/diagnostics@2.0.3':
     dependencies:
@@ -4036,7 +4051,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -4050,7 +4065,7 @@ snapshots:
   '@eslint/eslintrc@3.1.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       espree: 10.0.1
       globals: 14.0.0
       ignore: 5.3.1
@@ -4070,7 +4085,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -4276,6 +4291,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
+    optional: true
 
   '@mole-inc/bin-wrapper@8.0.1':
     dependencies:
@@ -4386,7 +4402,7 @@ snapshots:
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       import-from-esm: 1.3.4
       lodash-es: 4.17.21
       micromatch: 4.0.7
@@ -4402,7 +4418,7 @@ snapshots:
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       dir-glob: 3.0.1
       execa: 5.1.1
       lodash: 4.17.21
@@ -4420,7 +4436,7 @@ snapshots:
       '@octokit/plugin-throttling': 9.3.0(@octokit/core@6.1.2)
       '@semantic-release/error': 4.0.0
       aggregate-error: 5.0.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       dir-glob: 3.0.1
       globby: 14.0.1
       http-proxy-agent: 7.0.2
@@ -4457,7 +4473,7 @@ snapshots:
       conventional-changelog-writer: 8.0.0
       conventional-commits-filter: 5.0.0
       conventional-commits-parser: 6.0.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       get-stream: 7.0.1
       import-from-esm: 1.3.4
       into-stream: 7.0.0
@@ -4482,6 +4498,30 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@swc-node/core@1.13.1(@swc/core@1.6.1)(@swc/types@0.1.8)':
+    dependencies:
+      '@swc/core': 1.6.1
+      '@swc/types': 0.1.8
+
+  '@swc-node/register@1.9.2(@swc/core@1.6.1)(@swc/types@0.1.8)(typescript@5.4.5)':
+    dependencies:
+      '@swc-node/core': 1.13.1(@swc/core@1.6.1)(@swc/types@0.1.8)
+      '@swc-node/sourcemap-support': 0.5.0
+      '@swc/core': 1.6.1
+      colorette: 2.0.20
+      debug: 4.3.5(supports-color@5.5.0)
+      pirates: 4.0.6
+      tslib: 2.6.3
+      typescript: 5.4.5
+    transitivePeerDependencies:
+      - '@swc/types'
+      - supports-color
+
+  '@swc-node/sourcemap-support@0.5.0':
+    dependencies:
+      source-map-support: 0.5.21
+      tslib: 2.6.3
 
   '@swc/cli@0.3.12(@swc/core@1.6.1)(chokidar@3.6.0)':
     dependencies:
@@ -4563,13 +4603,17 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node10@1.0.11':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4682,10 +4726,6 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
-  '@types/strip-bom@3.0.0': {}
-
-  '@types/strip-json-comments@0.0.30': {}
-
   '@types/triple-beam@1.3.5': {}
 
   '@types/uuid@9.0.8': {}
@@ -4722,7 +4762,7 @@ snapshots:
       '@typescript-eslint/types': 7.13.0
       '@typescript-eslint/typescript-estree': 7.13.0(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 7.13.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.4.5
@@ -4738,7 +4778,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.13.0(typescript@5.4.5)
       '@typescript-eslint/utils': 7.13.0(eslint@8.57.0)(typescript@5.4.5)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
     optionalDependencies:
@@ -4752,7 +4792,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.13.0
       '@typescript-eslint/visitor-keys': 7.13.0
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.4
@@ -4793,12 +4833,13 @@ snapshots:
   acorn-walk@8.3.3:
     dependencies:
       acorn: 8.12.0
+    optional: true
 
   acorn@8.12.0: {}
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -4848,7 +4889,8 @@ snapshots:
 
   arch@2.2.0: {}
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -5175,6 +5217,8 @@ snapshots:
       color-convert: 1.9.3
       color-string: 1.9.1
 
+  colorette@2.0.20: {}
+
   colorspace@1.1.4:
     dependencies:
       color: 3.2.1
@@ -5262,7 +5306,8 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   cross-spawn@5.1.0:
     dependencies:
@@ -5306,9 +5351,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.3.5:
+  debug@4.3.5(supports-color@5.5.0):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 5.5.0
 
   decompress-response@6.0.0:
     dependencies:
@@ -5351,7 +5398,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -5374,10 +5422,6 @@ snapshots:
   duplexer2@0.1.4:
     dependencies:
       readable-stream: 2.3.8
-
-  dynamic-dedupe@0.3.0:
-    dependencies:
-      xtend: 4.0.2
 
   ee-first@1.1.1: {}
 
@@ -5525,7 +5569,7 @@ snapshots:
 
   eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
       eslint-module-utils: 2.8.1(@typescript-eslint/parser@7.13.0(eslint@8.57.0)(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.13.0(eslint@8.57.0)(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
@@ -5613,7 +5657,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -6120,7 +6164,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6132,7 +6176,7 @@ snapshots:
   https-proxy-agent@7.0.4:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6148,6 +6192,8 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  ignore-by-default@1.0.1: {}
+
   ignore@5.3.1: {}
 
   import-fresh@3.3.0:
@@ -6157,7 +6203,7 @@ snapshots:
 
   import-from-esm@1.3.4:
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       import-meta-resolve: 4.1.0
     transitivePeerDependencies:
       - supports-color
@@ -6340,7 +6386,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -6849,8 +6895,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  mkdirp@1.0.4: {}
-
   ms@2.0.0: {}
 
   ms@2.1.2: {}
@@ -6893,6 +6937,19 @@ snapshots:
   node-int64@0.4.0: {}
 
   node-releases@2.0.14: {}
+
+  nodemon@3.1.4:
+    dependencies:
+      chokidar: 3.6.0
+      debug: 4.3.5(supports-color@5.5.0)
+      ignore-by-default: 1.0.1
+      minimatch: 3.1.2
+      pstree.remy: 1.1.8
+      semver: 7.6.2
+      simple-update-notifier: 2.0.0
+      supports-color: 5.5.0
+      touch: 3.1.1
+      undefsafe: 2.0.5
 
   normalize-package-data@6.0.1:
     dependencies:
@@ -7153,6 +7210,8 @@ snapshots:
 
   pseudomap@1.0.2: {}
 
+  pstree.remy@1.1.8: {}
+
   pump@3.0.0:
     dependencies:
       end-of-stream: 1.4.4
@@ -7273,10 +7332,6 @@ snapshots:
 
   reusify@1.0.4: {}
 
-  rimraf@2.7.1:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
@@ -7315,7 +7370,7 @@ snapshots:
       '@semantic-release/release-notes-generator': 14.0.0(semantic-release@24.0.0(typescript@5.4.5))
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.0(typescript@5.4.5)
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       env-ci: 11.0.0
       execa: 9.2.0
       figures: 6.1.0
@@ -7432,6 +7487,10 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.6.2
 
   sisteransi@1.0.5: {}
 
@@ -7574,7 +7633,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.3.5
+      debug: 4.3.5(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
       formidable: 3.5.1
@@ -7609,6 +7668,15 @@ snapshots:
       supports-color: 7.2.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  swc-node@1.0.0(@swc/core@1.6.1)(@swc/types@0.1.8)(typescript@5.4.5):
+    dependencies:
+      '@swc-node/register': 1.9.2(@swc/core@1.6.1)(@swc/types@0.1.8)(typescript@5.4.5)
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/types'
+      - supports-color
+      - typescript
 
   tapable@2.2.1: {}
 
@@ -7663,13 +7731,13 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  touch@3.1.1: {}
+
   traverse@0.6.9:
     dependencies:
       gopd: 1.0.1
       typedarray.prototype.slice: 1.0.3
       which-typed-array: 1.1.15
-
-  tree-kill@1.2.2: {}
 
   trim-repeated@2.0.0:
     dependencies:
@@ -7699,24 +7767,6 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.24.7)
 
-  ts-node-dev@2.0.0(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5):
-    dependencies:
-      chokidar: 3.6.0
-      dynamic-dedupe: 0.3.0
-      minimist: 1.2.8
-      mkdirp: 1.0.4
-      resolve: 1.22.8
-      rimraf: 2.7.1
-      source-map-support: 0.5.21
-      tree-kill: 1.2.2
-      ts-node: 10.9.2(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5)
-      tsconfig: 7.0.0
-      typescript: 5.4.5
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-
   ts-node@10.9.2(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -7736,6 +7786,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.6.1
+    optional: true
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -7744,14 +7795,9 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsconfig@7.0.0:
-    dependencies:
-      '@types/strip-bom': 3.0.0
-      '@types/strip-json-comments': 0.0.30
-      strip-bom: 3.0.0
-      strip-json-comments: 2.0.1
-
   tslib@1.14.1: {}
+
+  tslib@2.6.3: {}
 
   tsyringe@4.8.0:
     dependencies:
@@ -7831,6 +7877,8 @@ snapshots:
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
 
+  undefsafe@2.0.5: {}
+
   undici-types@5.26.5: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
@@ -7865,7 +7913,8 @@ snapshots:
 
   uuid@10.0.0: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.2.0:
     dependencies:
@@ -7995,7 +8044,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       express-validator:
         specifier: ^7.1.0
         version: 7.1.0
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
       semantic-release:
         specifier: ^24.0.0
         version: 24.0.0(typescript@5.4.5)
@@ -3043,9 +3040,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  reflect-metadata@0.2.2:
-    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
@@ -7141,8 +7135,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  reflect-metadata@0.2.2: {}
 
   regexp.prototype.flags@1.5.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
+      supertest:
+        specifier: ^7.0.0
+        version: 7.0.0
       ts-jest:
         specifier: ^29.1.5
         version: 29.1.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.14.2)(ts-node@10.9.2(@swc/core@1.6.1)(@types/node@20.14.2)(typescript@5.4.5)))(typescript@5.4.5)
@@ -994,8 +997,14 @@ packages:
     resolution: {integrity: sha512-bMxMKAjg13EBSVscxTaYA4mRc5t1UAXa2kXiGTNfZ079HIWXEkKmkgFrh/nJqamaLSrXO5H4WFFkPEaLJWbs3A==}
     engines: {node: '>= 0.4'}
 
+  asap@2.0.6:
+    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
+
   async@3.2.5:
     resolution: {integrity: sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1197,12 +1206,19 @@ packages:
   colorspace@1.1.4:
     resolution: {integrity: sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  component-emitter@1.3.1:
+    resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -1252,6 +1268,9 @@ packages:
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  cookiejar@2.1.4:
+    resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -1356,6 +1375,10 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1367,6 +1390,9 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  dezalgo@1.0.4:
+    resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -1676,6 +1702,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
   fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
 
@@ -1756,6 +1785,13 @@ packages:
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
+
+  form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+
+  formidable@3.5.1:
+    resolution: {integrity: sha512-WJWKelbRHN41m5dumb0/k8TeAx7Id/y3a+Z7QfhxP/htI9Js5zYaEDtG8uMgG0vM0lOlqnmjE99/kfpOYi/0Og==}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1930,6 +1966,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hexoid@1.0.0:
+    resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
+    engines: {node: '>=8'}
 
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
@@ -2526,6 +2566,11 @@ packages:
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
     hasBin: true
 
   mime@4.0.3:
@@ -3349,6 +3394,14 @@ packages:
   super-regex@1.0.0:
     resolution: {integrity: sha512-CY8u7DtbvucKuquCmOFEKhr9Besln7n9uN8eFbwcoGYWXOMW07u2o8njWaiXt11ylS3qoGF55pILjRmPlbodyg==}
     engines: {node: '>=18'}
+
+  superagent@9.0.2:
+    resolution: {integrity: sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==}
+    engines: {node: '>=14.18.0'}
+
+  supertest@7.0.0:
+    resolution: {integrity: sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==}
+    engines: {node: '>=14.18.0'}
 
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -4859,7 +4912,11 @@ snapshots:
       is-array-buffer: 3.0.4
       is-shared-array-buffer: 1.0.3
 
+  asap@2.0.6: {}
+
   async@3.2.5: {}
+
+  asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -5123,12 +5180,18 @@ snapshots:
       color: 3.2.1
       text-hex: 1.0.0
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   commander@8.3.0: {}
 
   compare-func@2.0.0:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
+
+  component-emitter@1.3.1: {}
 
   concat-map@0.0.1: {}
 
@@ -5170,6 +5233,8 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie@0.6.0: {}
+
+  cookiejar@2.1.4: {}
 
   core-util-is@1.0.3: {}
 
@@ -5271,11 +5336,18 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
 
   detect-newline@3.1.0: {}
+
+  dezalgo@1.0.4:
+    dependencies:
+      asap: 2.0.6
+      wrappy: 1.0.2
 
   diff-sequences@29.6.3: {}
 
@@ -5728,6 +5800,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-safe-stringify@2.1.1: {}
+
   fastq@1.17.1:
     dependencies:
       reusify: 1.0.4
@@ -5822,6 +5896,18 @@ snapshots:
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.0:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  formidable@3.5.1:
+    dependencies:
+      dezalgo: 1.0.4
+      hexoid: 1.0.0
+      once: 1.4.0
 
   forwarded@0.2.0: {}
 
@@ -6008,6 +6094,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hexoid@1.0.0: {}
 
   highlight.js@10.7.3: {}
 
@@ -6738,6 +6826,8 @@ snapshots:
       mime-db: 1.52.0
 
   mime@1.6.0: {}
+
+  mime@2.6.0: {}
 
   mime@4.0.3: {}
 
@@ -7479,6 +7569,27 @@ snapshots:
     dependencies:
       function-timeout: 1.0.2
       time-span: 5.1.0
+
+  superagent@9.0.2:
+    dependencies:
+      component-emitter: 1.3.1
+      cookiejar: 2.1.4
+      debug: 4.3.5
+      fast-safe-stringify: 2.1.1
+      form-data: 4.0.0
+      formidable: 3.5.1
+      methods: 1.1.2
+      mime: 2.6.0
+      qs: 6.11.0
+    transitivePeerDependencies:
+      - supports-color
+
+  supertest@7.0.0:
+    dependencies:
+      methods: 1.1.2
+      superagent: 9.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@5.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       express-validator:
         specifier: ^7.1.0
         version: 7.1.0
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
       semantic-release:
         specifier: ^24.0.0
         version: 24.0.0(typescript@5.4.5)
@@ -3040,6 +3043,9 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
@@ -7135,6 +7141,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  reflect-metadata@0.2.2: {}
 
   regexp.prototype.flags@1.5.2:
     dependencies:

--- a/src/api/applicationFactory.ts
+++ b/src/api/applicationFactory.ts
@@ -1,0 +1,14 @@
+import App from '../infrastructure/base/api/app';
+import WebApp from './webApp';
+
+export default class ApplicationFactory {
+  static create = (appName: string, startListening = true): App => {
+    if (!appName) {
+      throw new Error('APP_NAME must be defined');
+    }
+
+    if (appName === 'webapi') return new WebApp(appName, startListening);
+
+    throw new Error('Could not create Application. Check for a valid APP_NAME');
+  };
+}

--- a/src/api/bootstrapper.ts
+++ b/src/api/bootstrapper.ts
@@ -1,9 +1,31 @@
 import { DependencyContainer } from 'tsyringe';
 import Logger from '../infrastructure/log/logger';
+import DummyPublisher from '../infrastructure/messaging/publisher/dummyPublisher';
+import Publisher from '../infrastructure/messaging/publisher/publisher';
+import DummySender from '../infrastructure/messaging/sender/dummySender';
+import Sender from '../infrastructure/messaging/sender/sender';
+
+const registerMessageSender = async (
+  container: DependencyContainer
+): Promise<void> => {
+  container.register<Sender>('Sender', {
+    useClass: DummySender
+  });
+};
+
+const registerMessagePublisher = async (
+  container: DependencyContainer
+): Promise<void> => {
+  container.register<Publisher>('Publisher', {
+    useClass: DummyPublisher
+  });
+};
 
 export default async (container: DependencyContainer): Promise<void> => {
   Logger.debug('Bootstrapper initializing...');
   // Be careful, the order of these calls are important
+  await registerMessageSender(container);
+  await registerMessagePublisher(container);
 
   Logger.debug('Bootstrapper initialized!');
 };

--- a/src/api/bootstrapper.ts
+++ b/src/api/bootstrapper.ts
@@ -1,0 +1,9 @@
+import { DependencyContainer } from 'tsyringe';
+import Logger from '../infrastructure/log/logger';
+
+export default async (container: DependencyContainer): Promise<void> => {
+  Logger.debug('Bootstrapper initializing...');
+  // Be careful, the order of these calls are important
+
+  Logger.debug('Bootstrapper initialized!');
+};

--- a/src/api/bootstrapper.ts
+++ b/src/api/bootstrapper.ts
@@ -1,9 +1,17 @@
 import { DependencyContainer } from 'tsyringe';
+import BookingRepository from '../domain/booking/bookingRepository';
 import Logger from '../infrastructure/log/logger';
 import DummyPublisher from '../infrastructure/messaging/publisher/dummyPublisher';
 import Publisher from '../infrastructure/messaging/publisher/publisher';
 import DummySender from '../infrastructure/messaging/sender/dummySender';
 import Sender from '../infrastructure/messaging/sender/sender';
+import DummyBookingRepository from '../repositories/dummyDb/booking/dummyBookingRepository';
+
+const registerRepos = async (container: DependencyContainer): Promise<void> => {
+  container.register<BookingRepository>('BookingRepository', {
+    useClass: DummyBookingRepository
+  });
+};
 
 const registerMessageSender = async (
   container: DependencyContainer
@@ -24,6 +32,7 @@ const registerMessagePublisher = async (
 export default async (container: DependencyContainer): Promise<void> => {
   Logger.debug('Bootstrapper initializing...');
   // Be careful, the order of these calls are important
+  await registerRepos(container);
   await registerMessageSender(container);
   await registerMessagePublisher(container);
 

--- a/src/api/health/healthController.ts
+++ b/src/api/health/healthController.ts
@@ -1,0 +1,24 @@
+import { Request, Response } from 'express';
+import { injectable } from 'tsyringe';
+import ExpressController from '../../infrastructure/base/api/expressController';
+import Logger from '../../infrastructure/log/logger';
+
+@injectable()
+export default class HealthController implements ExpressController {
+  validations = [];
+
+  handle = async (req: Request, res: Response): Promise<void> => {
+    Logger.debug('handle - Calling Health Check');
+
+    const check = {
+      app: process.env.APP_NAME,
+      status: 'healthy',
+      uptime: process.uptime(),
+      timestamp: Date.now(),
+      httpStatus: 200
+    };
+
+    res.status(check.httpStatus).send(check);
+    Logger.debug('handle - Called Health Check');
+  };
+}

--- a/src/api/makeBooking/makeBookingController.ts
+++ b/src/api/makeBooking/makeBookingController.ts
@@ -9,7 +9,7 @@ import MakeBooking from '../../useCases/makeBooking/makeBooking';
 @injectable()
 export default class MakeBookingController implements ExpressController {
   validations = [
-    check('date').isDate(),
+    check('date').isISO8601().toDate(),
     check('flightNumber').isNumeric(),
     check('customer.name').trim().notEmpty(),
     check('customer.email').trim().notEmpty().isEmail(),

--- a/src/api/makeBooking/makeBookingController.ts
+++ b/src/api/makeBooking/makeBookingController.ts
@@ -1,0 +1,49 @@
+import { Request, Response } from 'express';
+import { check, validationResult } from 'express-validator';
+import { inject, injectable } from 'tsyringe';
+import ExpressController from '../../infrastructure/base/api/expressController';
+import HTTPStatus from '../../infrastructure/base/api/httpStatus';
+import Logger from '../../infrastructure/log/logger';
+import MakeBooking from '../../useCases/makeBooking/makeBooking';
+
+@injectable()
+export default class MakeBookingController implements ExpressController {
+  validations = [
+    check('date').isDate(),
+    check('flightNumber').isNumeric(),
+    check('customer.name').trim().notEmpty(),
+    check('customer.email').trim().notEmpty().isEmail(),
+    check('passengers').isArray(),
+    check('passengers.*.name').trim().notEmpty(),
+    check('passengers.*.passportNumber').trim().notEmpty()
+  ];
+
+  constructor(@inject(MakeBooking) public readonly useCase: MakeBooking) {}
+
+  handle = async (req: Request, res: Response): Promise<void> => {
+    try {
+      Logger.debug('handle - Calling use case MakeBooking');
+
+      const schemaErrors = validationResult(req);
+
+      if (!schemaErrors.isEmpty()) {
+        res.status(HTTPStatus.BAD_REQUEST).send(schemaErrors.array());
+        return;
+      }
+
+      const output = await this.useCase.execute(req.body);
+
+      Logger.debug('handle - Called use case MakeBooking');
+
+      res.send(output);
+    } catch (error) {
+      Logger.error(
+        `handle - Error in MakeBookingController: ${error.message}`,
+        {
+          constructor: this.constructor.name
+        }
+      );
+      res.status(HTTPStatus.INTERNAL_SERVER_ERROR).send(error.message);
+    }
+  };
+}

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { container } from 'tsyringe';
+import HealthController from './health/healthController';
+
+export default async (): Promise<Router> => {
+  const router = Router();
+
+  const healthController = container.resolve(HealthController);
+  router.get('/', healthController.handle);
+
+  return router;
+};

--- a/src/api/router.ts
+++ b/src/api/router.ts
@@ -1,12 +1,20 @@
 import { Router } from 'express';
 import { container } from 'tsyringe';
 import HealthController from './health/healthController';
+import MakeBookingController from './makeBooking/makeBookingController';
 
 export default async (): Promise<Router> => {
   const router = Router();
 
   const healthController = container.resolve(HealthController);
   router.get('/', healthController.handle);
+
+  const makeBookingController = container.resolve(MakeBookingController);
+  router.post(
+    '/makeBooking',
+    makeBookingController.validations,
+    makeBookingController.handle
+  );
 
   return router;
 };

--- a/src/api/webApp.ts
+++ b/src/api/webApp.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import os from 'os';
+import { container } from 'tsyringe';
+import App from '../infrastructure/base/api/app';
+import Logger from '../infrastructure/log/logger';
+import bootstrapper from './bootstrapper';
+import routes from './router';
+
+export default class WebApp implements App {
+  constructor(appName: string, startListening = true) {
+    this.#startListening = startListening;
+    this.#appName = appName;
+  }
+
+  #appName: string;
+
+  #startListening: boolean;
+
+  #expressApp!: express.Application;
+
+  public get getApp(): unknown {
+    return this.#expressApp;
+  }
+
+  start = async (): Promise<void> => {
+    await bootstrapper(container);
+
+    await this.#proceedInitialization();
+  };
+
+  #listen = async (): Promise<void> => {
+    const port = process.env.APP_PORT || 4500;
+
+    this.#expressApp.listen(port, async () => {
+      Logger.info(
+        `App ${this.#appName} listening on http://${os.hostname}:${port} 🤟🤟🤟`
+      );
+    });
+  };
+
+  #proceedInitialization = async (): Promise<void> => {
+    this.#expressApp = express();
+    this.#expressApp.use(express.json());
+    this.#expressApp.use(await routes());
+
+    if (this.#startListening) await this.#listen();
+  };
+}

--- a/src/api/webApp.ts
+++ b/src/api/webApp.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import os from 'os';
 import { container } from 'tsyringe';
 import App from '../infrastructure/base/api/app';
 import Logger from '../infrastructure/log/logger';
@@ -32,9 +31,7 @@ export default class WebApp implements App {
     const port = process.env.APP_PORT || 4500;
 
     this.#expressApp.listen(port, async () => {
-      Logger.info(
-        `App ${this.#appName} listening on http://${os.hostname}:${port} 🤟🤟🤟`
-      );
+      Logger.info(`App ${this.#appName} listening on port ${port} 🤟🤟🤟`);
     });
   };
 

--- a/src/domain/booking/booking.ts
+++ b/src/domain/booking/booking.ts
@@ -1,15 +1,16 @@
 import BookingStatus from './bookingStatus';
 import Passenger from './passenger';
 
-interface FlightReservation {
+type Tickets = {
   ticketNumber: string;
+  passenger: Passenger;
   reservationStatus: 'OK' | 'DENIED';
-}
+};
 
-interface Customer {
+type Customer = {
   name: string;
   email: string;
-}
+};
 
 export default class Booking {
   constructor(
@@ -24,6 +25,7 @@ export default class Booking {
     this.status = BookingStatus.CREATED;
     this.passengers = passengers;
     this.flightNumber = flightNumber;
+    this.tickets = undefined;
     this.customer = customer;
 
     if (!passengers.length)
@@ -42,7 +44,7 @@ export default class Booking {
 
   flightNumber: string;
 
-  reservation?: FlightReservation;
+  tickets?: Tickets[];
 
   customer: Customer;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import * as dotenv from 'dotenv';
-import 'reflect-metadata';
 import Logger from './infrastructure/log/logger';
 
 dotenv.config();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,18 @@
 import * as dotenv from 'dotenv';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'reflect-metadata';
+import ApplicationFactory from './api/applicationFactory';
 import Logger from './infrastructure/log/logger';
 
 dotenv.config();
 
-const appName = process.env.APP_NAME || '';
+const appName = process.env.APP_NAME ?? process.argv.slice(2)[0];
 
 (async (): Promise<void> => {
-  Logger.info(`Initializing app ${appName}`);
-  // const app = ApplicationFactory.create(appName, false);
+  Logger.info(`Initializing app "${appName}"`);
+  const app = ApplicationFactory.create(appName);
 
-  // app.start();
+  app.start();
 })().catch(err => {
   Logger.error(`FATAL ERROR: ${err}`);
 });

--- a/src/infrastructure/messaging/sender/dummySender.ts
+++ b/src/infrastructure/messaging/sender/dummySender.ts
@@ -4,17 +4,19 @@ import Sender from './sender';
 
 export default class DummySender implements Sender {
   send = async (message: QueueMessage): Promise<void> => {
-    Logger.info(`Dummy Message Sender - ${message.constructor.name} Sent`, {
+    Logger.info(
+      `Dummy Message Sender - ${message.constructor.name} Sent`,
       message
-    });
+    );
   };
 
   sendMany = async (
     message: QueueMessage[],
     queueName: string
   ): Promise<void> => {
-    Logger.info(`Dummy Message Sender - ${message.constructor.name} Sent`, {
+    Logger.info(
+      `Dummy Message Sender - ${message.constructor.name} Sent`,
       message
-    });
+    );
   };
 }

--- a/src/repositories/dummyDb/booking/dummyBookingRepository.ts
+++ b/src/repositories/dummyDb/booking/dummyBookingRepository.ts
@@ -1,0 +1,14 @@
+import { injectable } from 'tsyringe';
+import Booking from '../../../domain/booking/booking';
+import BookingRepository from '../../../domain/booking/bookingRepository';
+import Logger from '../../../infrastructure/log/logger';
+
+@injectable()
+export default class DummyBookingRepository implements BookingRepository {
+  constructor() {}
+
+  save = async (booking: Booking): Promise<Booking> => {
+    Logger.debug('DummyDB: Booking saved', booking);
+    return booking;
+  };
+}

--- a/src/useCases/commands/EmitTicketsCommand.ts
+++ b/src/useCases/commands/EmitTicketsCommand.ts
@@ -1,19 +1,19 @@
 import Command from '../../infrastructure/messaging/command';
 
-type MakeFlightReservationCommandPassenger = {
+type EmitTicketsCommandPassenger = {
   name: string;
   passportNumber: string;
 };
 
-export default class MakeFlightReservationCommand extends Command {
-  readonly queueName = process.env.QUEUE_FLIGHT_RESERVATION!;
+export default class EmitTicketsCommand extends Command {
+  readonly queueName = process.env.QUEUE_EMIT_TICKETS!;
 
-  readonly commandName = 'MakeFlightReservationCommand';
+  readonly commandName = 'EmitTicketsCommand';
 
   constructor(
     bookingId: string,
     date: Date,
-    passengers: MakeFlightReservationCommandPassenger[],
+    passengers: EmitTicketsCommandPassenger[],
     flightNumber: string
   ) {
     super();
@@ -28,7 +28,7 @@ export default class MakeFlightReservationCommand extends Command {
 
   date: Date;
 
-  passengers: MakeFlightReservationCommandPassenger[];
+  passengers: EmitTicketsCommandPassenger[];
 
   flightNumber: string;
 }

--- a/src/useCases/makeBooking/makeBooking.ts
+++ b/src/useCases/makeBooking/makeBooking.ts
@@ -9,7 +9,7 @@ import UseCaseSync from '../../infrastructure/base/useCase/useCaseSync';
 import Logger from '../../infrastructure/log/logger';
 import Publisher from '../../infrastructure/messaging/publisher/publisher';
 import Sender from '../../infrastructure/messaging/sender/sender';
-import MakeFlightReservationCommand from '../commands/processBookingRequestCommand';
+import EmitTicketsCommand from '../commands/EmitTicketsCommand';
 
 export interface MakeBookingInput extends UseCaseInput {
   date: Date;
@@ -30,7 +30,7 @@ export default class MakeBooking implements UseCaseSync {
     @inject('Publisher') public readonly publisher: Publisher
   ) {}
 
-  async execute(input: MakeBookingInput): Promise<UseCaseOutput> {
+  async execute(input: MakeBookingInput): Promise<MakeBookingOutput> {
     try {
       // Cria o objeto de domínio
       const booking = new Booking(
@@ -56,7 +56,7 @@ export default class MakeBooking implements UseCaseSync {
 
       // Envia ordem para próxima fase (async)
       await this.sender.send(
-        new MakeFlightReservationCommand(
+        new EmitTicketsCommand(
           booking.bookingId,
           booking.date,
           booking.passengers,

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,4 +1,6 @@
 import * as dotenv from 'dotenv';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'reflect-metadata';
 
 dotenv.config();
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,5 +1,4 @@
 import * as dotenv from 'dotenv';
-import 'reflect-metadata';
 
 dotenv.config();
 

--- a/tests/testApp.ts
+++ b/tests/testApp.ts
@@ -1,0 +1,9 @@
+import ApplicationFactory from '../src/api/applicationFactory';
+import App from '../src/infrastructure/base/api/app';
+
+const app = ApplicationFactory.create('webapi', false);
+
+export default async (): Promise<App> => {
+  await app.start();
+  return app;
+};

--- a/tests/unit/api/makeBooking/makeBookingController.test.ts
+++ b/tests/unit/api/makeBooking/makeBookingController.test.ts
@@ -1,0 +1,43 @@
+import { faker } from '@faker-js/faker';
+import request from 'supertest';
+import App from '../../../../src/infrastructure/base/api/app';
+import HTTPStatus from '../../../../src/infrastructure/base/api/httpStatus';
+import testApp from '../../../testApp';
+
+describe('ListFilesController testing', () => {
+  let app: App;
+
+  beforeAll(async () => {
+    app = await testApp();
+  });
+
+  beforeEach(async () => {});
+
+  it('Should return 200 and on a proper /makeBooking call', async () => {
+    const payload = {
+      date: faker.date.soon(),
+      flightNumber: faker.number.int(),
+      customer: {
+        name: faker.person.fullName(),
+        email: faker.internet.email()
+      },
+      passengers: [
+        {
+          name: faker.person.fullName(),
+          passportNumber: faker.string.alpha(6)
+        }
+      ]
+    };
+
+    console.error(payload);
+
+    const res = await request(app.getApp).post('/makeBooking').send(payload);
+
+    expect(res.status).toEqual(HTTPStatus.OK);
+    expect(res.body).toMatchObject([
+      { fileName: 'file1' },
+      { fileName: 'file2' },
+      { fileName: 'file3' }
+    ]);
+  });
+});

--- a/tests/unit/api/makeBooking/makeBookingController.test.ts
+++ b/tests/unit/api/makeBooking/makeBookingController.test.ts
@@ -15,8 +15,8 @@ describe('ListFilesController testing', () => {
 
   it('Should return 200 and on a proper /makeBooking call', async () => {
     const payload = {
-      date: faker.date.soon(),
-      flightNumber: faker.number.int(),
+      date: faker.date.soon().toISOString(),
+      flightNumber: faker.number.int(10000),
       customer: {
         name: faker.person.fullName(),
         email: faker.internet.email()
@@ -29,15 +29,9 @@ describe('ListFilesController testing', () => {
       ]
     };
 
-    console.error(payload);
-
     const res = await request(app.getApp).post('/makeBooking').send(payload);
 
     expect(res.status).toEqual(HTTPStatus.OK);
-    expect(res.body).toMatchObject([
-      { fileName: 'file1' },
-      { fileName: 'file2' },
-      { fileName: 'file3' }
-    ]);
+    expect(res.body.bookingId).toBeDefined();
   });
 });

--- a/tests/unit/useCases/makeBooking/makeBooking.test.ts
+++ b/tests/unit/useCases/makeBooking/makeBooking.test.ts
@@ -58,8 +58,8 @@ describe('MakeBooking Testing', () => {
       date: input.date,
       passengers: input.passengers,
       flightNumber: input.flightNumber,
-      commandName: 'MakeFlightReservationCommand',
-      queueName: process.env.QUEUE_FLIGHT_RESERVATION!,
+      commandName: 'EmitTicketsCommand',
+      queueName: process.env.QUEUE_EMIT_TICKETS!,
       delaySeconds: 1,
       attributes: {}
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 /* Visit https://aka.ms/tsconfig.json to read more about this file */
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs",
+    "target": "es2022",
+    "module": "es2022",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
@@ -16,5 +16,5 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src"],
-  "exclude": ["tests"]
+  "exclude": ["tests", "node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,9 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "Node"
   },
   "include": ["src"],
-  "exclude": ["tests", "node_modules"]
+  "exclude": ["tests"]
 }


### PR DESCRIPTION
### application layer for existing use case `makeBooking` 

#### Additions/Removals/Changes

- implemented controller for make booking with tests
- changed `Reservation` names to `EmitTickets`
- infra needed to up webapplication
- healthcheck
- dummy message senders
- fix makefiles typos and wrong references
- remove unnecessary lib reflect-metadata

#### Testing

1. run make test locally

<img width="527" alt="Screenshot 2024-06-23 at 17 31 10" src="https://github.com/fghbittencourt/node-clean-arch/assets/13143658/b92c5284-90e6-4914-8283-6871149e9bc6">

#### Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
