### PR TITLE
chore: hono simple api layer

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -8,7 +8,7 @@ export default {
   roots: ['<rootDir>/src/', '<rootDir>/tests/'],
   setupFilesAfterEnv: ['./tests/jest.setup.ts'],
   testEnvironment: 'node',
-  testMatch: ['**/tests/unit/**/*.test.ts'],
+  testMatch: ['**/tests/unit/**/*.test.ts', '**/tests/integration/**/*.test.ts'],
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
   },

--- a/package.json
+++ b/package.json
@@ -18,13 +18,18 @@
   },
   "dependencies": {
     "@fastify/helmet": "^11.1.1",
+    "@hono/node-server": "^1.11.4",
+    "@hono/swagger-ui": "^0.3.0",
+    "@hono/zod-openapi": "^0.14.5",
     "dotenv": "^16.4.5",
     "fastify": "^4.28.0",
+    "hono": "^4.4.9",
     "reflect-metadata": "^0.2.2",
     "semantic-release": "^24.0.0",
     "tsyringe": "^4.8.0",
     "uuid": "^10.0.0",
-    "winston": "^3.13.0"
+    "winston": "^3.13.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,12 +11,24 @@ importers:
       '@fastify/helmet':
         specifier: ^11.1.1
         version: 11.1.1
+      '@hono/node-server':
+        specifier: ^1.11.4
+        version: 1.11.4
+      '@hono/swagger-ui':
+        specifier: ^0.3.0
+        version: 0.3.0(hono@4.4.9)
+      '@hono/zod-openapi':
+        specifier: ^0.14.5
+        version: 0.14.5(hono@4.4.9)(zod@3.23.8)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
       fastify:
         specifier: ^4.28.0
         version: 4.28.0
+      hono:
+        specifier: ^4.4.9
+        version: 4.4.9
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -32,6 +44,9 @@ importers:
       winston:
         specifier: ^3.13.0
         version: 3.13.0
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.1.0
@@ -132,6 +147,11 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@asteasolutions/zod-to-openapi@7.1.1':
+    resolution: {integrity: sha512-lF0d1gAc0lYLO9/BAGivwTwE2Sh9h6CHuDcbk5KnGBfIuAsAkDC+Fdat4dkQY3CS/zUWKHRmFEma0B7X132Ymw==}
+    peerDependencies:
+      zod: ^3.20.2
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
@@ -359,6 +379,28 @@ packages:
 
   '@fastify/merge-json-schemas@0.1.1':
     resolution: {integrity: sha512-fERDVz7topgNjtXsJTTW1JKLy0rhuLRcquYqNR9rF7OcVpCa2OVW49ZPDIhaRRCaUuvVxI+N416xUoF76HNSXA==}
+
+  '@hono/node-server@1.11.4':
+    resolution: {integrity: sha512-8TOiiiAqcFC6f62P7M9p6adQREAlWdVi1awehAwgWW+3R65/rKzHnLARO/Hu/466z01VNViBoogqatqXJMyItA==}
+    engines: {node: '>=18.14.1'}
+
+  '@hono/swagger-ui@0.3.0':
+    resolution: {integrity: sha512-2Hp7XYFx5wDJoc6gKJAnV7RA5TWYgYl2G1k5b3BlaF6uxsePgqqCBkxhbJPe3oPu2XRB4Bsm2V7Dp9jq8LI+dg==}
+    peerDependencies:
+      hono: '*'
+
+  '@hono/zod-openapi@0.14.5':
+    resolution: {integrity: sha512-+CXmjUlWSvYd1dDUcq2umdCD5ReKpygIIsT8rAWYEM0EKFQOqg1w1y8SvWfwrP0dL8pkSZmcRatMjH9vPvzoGg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      hono: '>=4.3.6'
+      zod: 3.*
+
+  '@hono/zod-validator@0.2.2':
+    resolution: {integrity: sha512-dSDxaPV70Py8wuIU2QNpoVEIOSzSXZ/6/B/h4xA7eOMz7+AarKTSGV8E6QwrdcCbBLkpqfJ4Q2TmBO0eP1tCBQ==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.19.1
 
   '@humanwhocodes/config-array@0.11.14':
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -1967,6 +2009,10 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  hono@4.4.9:
+    resolution: {integrity: sha512-VW1hnYipHL/XsnSYiCTLJ+Z7iisZYWwSOiKXm9RBV2NKPxNqjfaHqeMFiDl11fK893ofmErvRpX20+FTNjZIjA==}
+    engines: {node: '>=16.0.0'}
+
   hook-std@3.0.0:
     resolution: {integrity: sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2785,6 +2831,9 @@ packages:
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  openapi3-ts@4.3.3:
+    resolution: {integrity: sha512-LKkzBGJcZ6wdvkKGMoSvpK+0cbN5Xc3XuYkJskO+vjEQWJgs1kgtyUk0pjf8KwPuysv323Er62F5P17XQl96Qg==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3738,6 +3787,11 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@2.4.5:
+    resolution: {integrity: sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==}
+    engines: {node: '>= 14'}
+    hasBin: true
+
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -3766,12 +3820,20 @@ packages:
     resolution: {integrity: sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==}
     engines: {node: '>=18'}
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
 snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@asteasolutions/zod-to-openapi@7.1.1(zod@3.23.8)':
+    dependencies:
+      openapi3-ts: 4.3.3
+      zod: 3.23.8
 
   '@babel/code-frame@7.24.7':
     dependencies:
@@ -4056,6 +4118,24 @@ snapshots:
   '@fastify/merge-json-schemas@0.1.1':
     dependencies:
       fast-deep-equal: 3.1.3
+
+  '@hono/node-server@1.11.4': {}
+
+  '@hono/swagger-ui@0.3.0(hono@4.4.9)':
+    dependencies:
+      hono: 4.4.9
+
+  '@hono/zod-openapi@0.14.5(hono@4.4.9)(zod@3.23.8)':
+    dependencies:
+      '@asteasolutions/zod-to-openapi': 7.1.1(zod@3.23.8)
+      '@hono/zod-validator': 0.2.2(hono@4.4.9)(zod@3.23.8)
+      hono: 4.4.9
+      zod: 3.23.8
+
+  '@hono/zod-validator@0.2.2(hono@4.4.9)(zod@3.23.8)':
+    dependencies:
+      hono: 4.4.9
+      zod: 3.23.8
 
   '@humanwhocodes/config-array@0.11.14':
     dependencies:
@@ -6044,6 +6124,8 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  hono@4.4.9: {}
+
   hook-std@3.0.0: {}
 
   hosted-git-info@7.0.2:
@@ -6923,6 +7005,10 @@ snapshots:
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  openapi3-ts@4.3.3:
+    dependencies:
+      yaml: 2.4.5
 
   optionator@0.9.4:
     dependencies:
@@ -7896,6 +7982,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yaml@2.4.5: {}
+
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
@@ -7925,3 +8013,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yoctocolors@2.0.2: {}
+
+  zod@3.23.8: {}

--- a/src/api/applicationFactory.ts
+++ b/src/api/applicationFactory.ts
@@ -1,6 +1,6 @@
 import App from '../infrastructure/base/api/app'
+import FastifyApp from './fastifyApp'
 import HonoApp from './honoApp'
-import WebApp from './webApp'
 
 export default class ApplicationFactory {
   static create = (appName: string, startListening = true): App => {
@@ -8,7 +8,7 @@ export default class ApplicationFactory {
       throw new Error('APP_NAME must be defined')
     }
 
-    if (appName === 'webapi') return new WebApp(appName, startListening)
+    if (appName === 'webapi') return new FastifyApp(appName, startListening)
 
     if (appName === 'honoapi') return new HonoApp()
 

--- a/src/api/applicationFactory.ts
+++ b/src/api/applicationFactory.ts
@@ -1,4 +1,5 @@
 import App from '../infrastructure/base/api/app'
+import HonoApp from './honoApp'
 import WebApp from './webApp'
 
 export default class ApplicationFactory {
@@ -8,6 +9,8 @@ export default class ApplicationFactory {
     }
 
     if (appName === 'webapi') return new WebApp(appName, startListening)
+
+    if (appName === 'honoapi') return new HonoApp()
 
     throw new Error('Could not create Application. Check for a valid APP_NAME')
   }

--- a/src/api/applicationFactory.ts
+++ b/src/api/applicationFactory.ts
@@ -10,7 +10,7 @@ export default class ApplicationFactory {
 
     if (appName === 'webapi') return new FastifyApp(appName, startListening)
 
-    if (appName === 'honoapi') return new HonoApp()
+    if (appName === 'honoapi') return new HonoApp(appName, startListening)
 
     throw new Error('Could not create Application. Check for a valid APP_NAME')
   }

--- a/src/api/booking/bookingRoute.ts
+++ b/src/api/booking/bookingRoute.ts
@@ -1,0 +1,58 @@
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
+import { container } from 'tsyringe'
+import { z } from 'zod'
+
+import Logger from '../../infrastructure/log/logger'
+import MakeBooking from '../../useCases/makeBooking/makeBooking'
+
+const app = new OpenAPIHono()
+
+const route = createRoute({
+  method: 'post',
+  name: 'booking',
+  path: '/',
+  request: {
+    body: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            customer: z.object({ email: z.string(), name: z.string() }),
+            date: z.coerce.date(),
+            flightNumber: z.number(),
+            passengers: z.array(
+              z.object(
+                {
+                  name: z.string(),
+                  passportNumber: z.string(),
+                },
+              ),
+            ),
+          }),
+        },
+      },
+      description: 'registar a new booking',
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        'application/json': {
+          schema: z.object({
+            bookingId: z.string(),
+          }),
+        },
+      },
+      description: 'Success',
+    },
+  },
+})
+app.openapi(route, async (c) => {
+  Logger.error(`Calling route ${route.name}`)
+  const uc = container.resolve(MakeBooking)
+  const input = await c.req.json()
+  const output = await uc.execute(input)
+
+  return c.json(output, 201)
+})
+
+export default app

--- a/src/api/bookings/bookingsRoute.ts
+++ b/src/api/bookings/bookingsRoute.ts
@@ -9,7 +9,7 @@ const app = new OpenAPIHono()
 
 const route = createRoute({
   method: 'post',
-  name: 'booking',
+  name: 'bookings',
   path: '/',
   request: {
     body: {

--- a/src/api/fastifyApp.ts
+++ b/src/api/fastifyApp.ts
@@ -31,17 +31,15 @@ export default class FastifyApp implements App {
 
   #startListening: boolean
 
-  ready = async (): Promise<void> => {
-    this.#app.ready()
-    this.server = this.#app.server
-  }
-
   server: unknown
 
   start = async (): Promise<void> => {
     await bootstrapper(container)
 
     await this.#proceedInitialization()
+
+    await this.#app.ready()
+    this.server = this.#app.server
   }
 
   constructor(appName: string, startListening = true) {

--- a/src/api/fastifyApp.ts
+++ b/src/api/fastifyApp.ts
@@ -7,7 +7,7 @@ import Logger from '../infrastructure/log/logger'
 import bootstrapper from './bootstrapper'
 import router from './router'
 
-export default class WebApp implements App {
+export default class FastifyApp implements App {
   #app!: FastifyInstance
 
   #appName: string

--- a/src/api/health/healthController.ts
+++ b/src/api/health/healthController.ts
@@ -21,7 +21,5 @@ export default class HealthController implements FastifyController {
     Logger.debug('handle - Called Health Check')
   }
 
-  schema: unknown
-
-  validations = []
+  schema = {}
 }

--- a/src/api/honoApp.ts
+++ b/src/api/honoApp.ts
@@ -9,6 +9,10 @@ import bookingRoute from './booking/bookingRoute'
 import bootstrapper from './bootstrapper'
 
 export default class HonoApp implements App {
+  #appName: string
+
+  #startListening: boolean
+
   server: unknown
 
   start = async (): Promise<void> => {
@@ -22,23 +26,30 @@ export default class HonoApp implements App {
     app.notFound((c) => c.text('Not found 🙁'))
     app.doc('/docs/json', {
       info: {
-        title: 'OpenAPI Hono 🚀',
+        title: `OpenAPI ${this.#appName} 🚀`,
         version: '1.0.0',
       },
       openapi: '3.0.0',
     })
     app.get('/docs', swaggerUI({ url: '/docs/json' }))
 
-    const port = 4500
-    Logger.info(`Hono Server is running on port ${port}`)
+    if (this.#startListening) {
+      const port = 4500
+      Logger.info(`Hono Server is running on port ${port}`)
 
-    serve({
-      fetch: app.fetch,
-      port,
-    })
+      serve({
+        fetch: app.fetch,
+        port,
+      })
+    }
+  }
+
+  constructor(appName: string, startListening = true) {
+    this.#startListening = startListening
+    this.#appName = appName
   }
 
   ready(): Promise<void> {
-    throw new Error('Method not implemented.')
+    Logger.debug('Hono ready')
   }
 }

--- a/src/api/honoApp.ts
+++ b/src/api/honoApp.ts
@@ -1,11 +1,11 @@
 import { serve } from '@hono/node-server'
 import { swaggerUI } from '@hono/swagger-ui'
-import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
+import { OpenAPIHono } from '@hono/zod-openapi'
 import { container } from 'tsyringe'
-import { z } from 'zod'
 
 import App from '../infrastructure/base/api/app'
 import Logger from '../infrastructure/log/logger'
+import bookingRoute from './booking/bookingRoute'
 import bootstrapper from './bootstrapper'
 
 export default class HonoApp implements App {
@@ -17,45 +17,12 @@ export default class HonoApp implements App {
     const app = new OpenAPIHono()
     this.server = app
 
-    // example route
-    const testRoute = createRoute({
-      method: 'post',
-      path: '/test',
-      request: {
-        body: {
-          content: {
-            'application/json': {
-              schema: z.object({
-                fullName: z.string().openapi({ example: 'João Cardoso' }),
-              }),
-            },
-          },
-          description: 'my method description',
-        },
-      },
-      responses: {
-        200: {
-          content: {
-            'application/json': {
-              schema: z.object({
-                hello: z.string(),
-              }),
-            },
-          },
-          description: 'say hello',
-        },
-      },
-    })
-    app.openapi(testRoute, async (c) => {
-      const body = await c.req.json()
-      Logger.debug(body)
-      return c.json({ hello: body.fullName }, 200)
-    })
+    app.route('/booking', bookingRoute) // <- add imported route here
 
-    // The openapi.json will be available at /doc
+    app.notFound((c) => c.text('Not found 🙁'))
     app.doc('/docs/json', {
       info: {
-        title: 'My API',
+        title: 'OpenAPI Hono 🚀',
         version: '1.0.0',
       },
       openapi: '3.0.0',

--- a/src/api/honoApp.ts
+++ b/src/api/honoApp.ts
@@ -1,0 +1,77 @@
+import { serve } from '@hono/node-server'
+import { swaggerUI } from '@hono/swagger-ui'
+import { OpenAPIHono, createRoute } from '@hono/zod-openapi'
+import { container } from 'tsyringe'
+import { z } from 'zod'
+
+import App from '../infrastructure/base/api/app'
+import Logger from '../infrastructure/log/logger'
+import bootstrapper from './bootstrapper'
+
+export default class HonoApp implements App {
+  server: unknown
+
+  start = async (): Promise<void> => {
+    await bootstrapper(container)
+
+    const app = new OpenAPIHono()
+    this.server = app
+
+    // example route
+    const testRoute = createRoute({
+      method: 'post',
+      path: '/test',
+      request: {
+        body: {
+          content: {
+            'application/json': {
+              schema: z.object({
+                fullName: z.string().openapi({ example: 'João Cardoso' }),
+              }),
+            },
+          },
+          description: 'my method description',
+        },
+      },
+      responses: {
+        200: {
+          content: {
+            'application/json': {
+              schema: z.object({
+                hello: z.string(),
+              }),
+            },
+          },
+          description: 'say hello',
+        },
+      },
+    })
+    app.openapi(testRoute, async (c) => {
+      const body = await c.req.json()
+      Logger.debug(body)
+      return c.json({ hello: body.fullName }, 200)
+    })
+
+    // The openapi.json will be available at /doc
+    app.doc('/docs/json', {
+      info: {
+        title: 'My API',
+        version: '1.0.0',
+      },
+      openapi: '3.0.0',
+    })
+    app.get('/docs', swaggerUI({ url: '/docs/json' }))
+
+    const port = 4500
+    Logger.info(`Hono Server is running on port ${port}`)
+
+    serve({
+      fetch: app.fetch,
+      port,
+    })
+  }
+
+  ready(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/src/api/honoApp.ts
+++ b/src/api/honoApp.ts
@@ -5,7 +5,7 @@ import { container } from 'tsyringe'
 
 import App from '../infrastructure/base/api/app'
 import Logger from '../infrastructure/log/logger'
-import bookingRoute from './booking/bookingRoute'
+import bookingsRoute from './bookings/bookingsRoute'
 import bootstrapper from './bootstrapper'
 
 export default class HonoApp implements App {
@@ -21,7 +21,7 @@ export default class HonoApp implements App {
     const app = new OpenAPIHono()
     this.server = app
 
-    app.route('/booking', bookingRoute) // <- add imported route here
+    app.route('/bookings', bookingsRoute) // <- add imported route here
 
     app.notFound((c) => c.text('Not found 🙁'))
     app.doc('/docs/json', {
@@ -47,9 +47,5 @@ export default class HonoApp implements App {
   constructor(appName: string, startListening = true) {
     this.#startListening = startListening
     this.#appName = appName
-  }
-
-  ready(): Promise<void> {
-    Logger.debug('Hono ready')
   }
 }

--- a/src/infrastructure/base/api/app.ts
+++ b/src/infrastructure/base/api/app.ts
@@ -1,5 +1,6 @@
 export default interface App {
   ready(): Promise<void>;
-  server: unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  server: any;
   start(): Promise<void>;
 }

--- a/src/infrastructure/base/api/app.ts
+++ b/src/infrastructure/base/api/app.ts
@@ -1,5 +1,4 @@
 export default interface App {
-  ready(): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server: any;
   start(): Promise<void>;

--- a/tests/integration/api/booking/bookingRoute.test.ts
+++ b/tests/integration/api/booking/bookingRoute.test.ts
@@ -1,20 +1,19 @@
 import { faker } from '@faker-js/faker'
-import request from 'supertest'
 
 import App from '../../../../src/infrastructure/base/api/app'
 import HTTPStatus from '../../../../src/infrastructure/base/api/httpStatus'
-import testApp from '../../../testApp'
+import { getHonoApp } from '../../../testApp'
 
-describe('ListFilesController testing', () => {
+describe('BookingRoute testing', () => {
   let app: App
 
   beforeAll(async () => {
-    app = await testApp()
+    app = await getHonoApp()
   })
 
   beforeEach(async () => {})
 
-  it('Should return 200 and on a proper /makeBooking call', async () => {
+  it('Should return 201 and on a proper /booking call', async () => {
     const payload = {
       customer: {
         email: faker.internet.email(),
@@ -29,10 +28,13 @@ describe('ListFilesController testing', () => {
         },
       ],
     }
+    const res = await app.server.request('/booking', {
+      body: JSON.stringify(payload),
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      method: 'POST',
+    })
 
-    const res = await request(app.server).post('/makeBooking').send(payload)
-
-    expect(res.status).toEqual(HTTPStatus.OK)
-    expect(res.body.bookingId).toBeDefined()
+    expect(res.status).toEqual(HTTPStatus.CREATED)
+    expect((await res.json()).bookingId).toBeDefined()
   })
 })

--- a/tests/integration/api/booking/bookingRoute.test.ts
+++ b/tests/integration/api/booking/bookingRoute.test.ts
@@ -4,7 +4,7 @@ import App from '../../../../src/infrastructure/base/api/app'
 import HTTPStatus from '../../../../src/infrastructure/base/api/httpStatus'
 import { getHonoApp } from '../../../testApp'
 
-describe('BookingRoute testing', () => {
+describe('Bookings Route testing', () => {
   let app: App
 
   beforeAll(async () => {
@@ -28,7 +28,7 @@ describe('BookingRoute testing', () => {
         },
       ],
     }
-    const res = await app.server.request('/booking', {
+    const res = await app.server.request('/bookings', {
       body: JSON.stringify(payload),
       headers: new Headers({ 'Content-Type': 'application/json' }),
       method: 'POST',

--- a/tests/integration/api/makeBooking/makeBookingController.test.ts
+++ b/tests/integration/api/makeBooking/makeBookingController.test.ts
@@ -1,0 +1,38 @@
+import { faker } from '@faker-js/faker'
+import request from 'supertest'
+
+import App from '../../../../src/infrastructure/base/api/app'
+import HTTPStatus from '../../../../src/infrastructure/base/api/httpStatus'
+import { getFastifyApp } from '../../../testApp'
+
+describe('MakeBookingController testing', () => {
+  let app: App
+
+  beforeAll(async () => {
+    app = await getFastifyApp()
+  })
+
+  beforeEach(async () => {})
+
+  it('Should return 200 and on a proper /makeBooking call', async () => {
+    const payload = {
+      customer: {
+        email: faker.internet.email(),
+        name: faker.person.fullName(),
+      },
+      date: faker.date.soon().toISOString(),
+      flightNumber: faker.number.int(10000),
+      passengers: [
+        {
+          name: faker.person.fullName(),
+          passportNumber: faker.string.alpha(6),
+        },
+      ],
+    }
+
+    const res = await request(app.server).post('/makeBooking').send(payload)
+
+    expect(res.status).toEqual(HTTPStatus.OK)
+    expect(res.body.bookingId).toBeDefined()
+  })
+})

--- a/tests/testApp.ts
+++ b/tests/testApp.ts
@@ -1,9 +1,14 @@
 import ApplicationFactory from '../src/api/applicationFactory'
-import App from '../src/infrastructure/base/api/app'
 
-const app = ApplicationFactory.create('webapi', false)
+export const getHonoApp = async () => {
+  const app = ApplicationFactory.create('honoapi', false)
+  await app.start()
+  await app.ready()
+  return app
+}
 
-export default async (): Promise<App> => {
+export const getFastifyApp = async () => {
+  const app = ApplicationFactory.create('webapi', false)
   await app.start()
   await app.ready()
   return app

--- a/tests/testApp.ts
+++ b/tests/testApp.ts
@@ -3,13 +3,11 @@ import ApplicationFactory from '../src/api/applicationFactory'
 export const getHonoApp = async () => {
   const app = ApplicationFactory.create('honoapi', false)
   await app.start()
-  await app.ready()
   return app
 }
 
 export const getFastifyApp = async () => {
   const app = ApplicationFactory.create('webapi', false)
   await app.start()
-  await app.ready()
   return app
 }


### PR DESCRIPTION
### HONO api layer

- added new type of routing in parallel to fastify (for didactic purposes) 
- added support to openAPI 3.0 and Swagger in [Hono](https://hono.dev/) router
- added validation thru Zod in the route
- added integration tests

The intention was to simplify the API layer, which I judge was a bit verbose. As a plus I added openapi support. I also kept the fastify implementation (controllers) to comparison effect

<img width="851" alt="Screenshot 2024-06-29 at 17 14 41" src="https://github.com/fghbittencourt/node-clean-arch/assets/13143658/cf9e3817-4673-48b4-a5fa-c8620c90f270">

#### Testing

- `make test` for tests
- run pnpm dev:webapi
- access localhost:4500/docs to check swagger documentation

#### Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows the standards laid out in the [development playbook](https://github.com/cfpb/development)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
